### PR TITLE
refactor: API 서버 관련 리소스 네이밍 변경

### DIFF
--- a/terraform/env/dev/compute.tf
+++ b/terraform/env/dev/compute.tf
@@ -19,7 +19,7 @@ module "bastion_dev" {
 module "api_dev" {
   source = "../../modules/compute/ec2"
 
-  ami_id                 = "ami-08943a151bd468f4e" // API Server backup AMI
+  ami_id                 = "ami-0436f6f455f7b550f" // API Server backup AMI
   instance_type          = "t2.micro"
   subnet_id              = module.public_subnet_1.id
   vpc_security_group_ids = [module.api_dev_sg.id]

--- a/terraform/env/dev/compute.tf
+++ b/terraform/env/dev/compute.tf
@@ -16,19 +16,19 @@ module "bastion_dev" {
   tags             = local.common_tags
 }
 
-module "was_dev" {
+module "api_dev" {
   source = "../../modules/compute/ec2"
 
-  ami_id                 = "ami-08943a151bd468f4e" // Was backup AMI
+  ami_id                 = "ami-08943a151bd468f4e" // API Server backup AMI
   instance_type          = "t2.micro"
   subnet_id              = module.public_subnet_1.id
-  vpc_security_group_ids = [module.was_dev_sg.id]
+  vpc_security_group_ids = [module.api_dev_sg.id]
   associate_public_ip    = true
-  key_name               = "cherrypic-was-dev-key"
+  key_name               = "cherrypic-api-dev-key"
 
   root_volume_size = 30
   root_volume_type = "gp2"
-  purpose          = "was"
+  purpose          = "api"
   environment      = local.env
 
   enable_eip        = true

--- a/terraform/env/dev/compute.tf
+++ b/terraform/env/dev/compute.tf
@@ -1,21 +1,3 @@
-module "bastion_dev" {
-  source = "../../modules/compute/ec2"
-
-  ami_id                 = "ami-06af2834df25fe45d" // Bastion backup AMI
-  instance_type          = "t2.micro"
-  subnet_id              = module.public_subnet_1.id
-  vpc_security_group_ids = [module.bastion_dev_sg.id]
-  associate_public_ip    = false
-  key_name               = "cherrypic-bastion-host-key"
-
-  root_volume_size = 30
-  root_volume_type = "gp3"
-  purpose          = "bastion-host"
-  environment      = ""
-  enable_eip       = false
-  tags             = local.common_tags
-}
-
 module "api_dev" {
   source = "../../modules/compute/ec2"
 

--- a/terraform/env/dev/network.tf
+++ b/terraform/env/dev/network.tf
@@ -36,11 +36,11 @@ module "private_route_table" {
 
 # ============= Security Group ===============
 
-module "was_dev_sg" {
+module "api_dev_sg" {
   source      = "../../modules/network/securitygroup"
-  purpose     = "was"
+  purpose     = "api"
   env         = local.env
-  description = "WAS Security Group"
+  description = "API Server Security Group"
   vpc_id      = module.vpc.id
 
   ingress_rules = [

--- a/terraform/env/dev/network.tf
+++ b/terraform/env/dev/network.tf
@@ -136,7 +136,7 @@ module "cache_dev_sg" {
       protocol                 = "tcp"
       use_cidr                 = false
       use_sg                   = true
-      source_security_group_id = module.bastion_dev_sg.id
+      source_security_group_id = module.api_dev_sg.id
     },
     {
       from_port                = 6379
@@ -144,8 +144,8 @@ module "cache_dev_sg" {
       protocol                 = "tcp"
       use_cidr                 = false
       use_sg                   = true
-      source_security_group_id = module.was_dev_sg.id
-    }
+      source_security_group_id = module.bastion_dev_sg.id
+    },
   ]
 
   egress_rules = [
@@ -174,7 +174,7 @@ module "db_dev_sg" {
       protocol                 = "tcp"
       use_cidr                 = false
       use_sg                   = true
-      source_security_group_id = module.was_dev_sg.id
+      source_security_group_id = module.api_dev_sg.id
     },
     {
       from_port                = 3306

--- a/terraform/env/dev/network.tf
+++ b/terraform/env/dev/network.tf
@@ -92,36 +92,6 @@ module "api_dev_sg" {
   tags = local.common_tags
 }
 
-module "bastion_dev_sg" {
-  source      = "../../modules/network/securitygroup"
-  purpose     = "bastion-host"
-  env         = ""
-  description = "Bastion Host Security Group"
-  vpc_id      = module.vpc.id
-
-  ingress_rules = [
-    {
-      from_port   = 22
-      to_port     = 22
-      protocol    = "tcp"
-      use_cidr    = true
-      use_sg      = false
-      cidr_blocks = ["0.0.0.0/0"]
-    }
-  ]
-
-  egress_rules = [
-    {
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
-    }
-  ]
-
-  tags = local.common_tags
-}
-
 module "cache_dev_sg" {
   source      = "../../modules/network/securitygroup"
   purpose     = "cache"
@@ -137,15 +107,7 @@ module "cache_dev_sg" {
       use_cidr                 = false
       use_sg                   = true
       source_security_group_id = module.api_dev_sg.id
-    },
-    {
-      from_port                = 6379
-      to_port                  = 6379
-      protocol                 = "tcp"
-      use_cidr                 = false
-      use_sg                   = true
-      source_security_group_id = module.bastion_dev_sg.id
-    },
+    }
   ]
 
   egress_rules = [
@@ -175,14 +137,6 @@ module "db_dev_sg" {
       use_cidr                 = false
       use_sg                   = true
       source_security_group_id = module.api_dev_sg.id
-    },
-    {
-      from_port                = 3306
-      to_port                  = 3306
-      protocol                 = "tcp"
-      use_cidr                 = false
-      use_sg                   = true
-      source_security_group_id = module.bastion_dev_sg.id
     }
   ]
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #13 

---
## 📌 작업 내용 및 특이사항
* 기존 was_dev 등의 네이밍을 api_dev 등으로 변경하였습니다.
  * 리소스 목적을 명확히 드러내기 위해 API 서버에 맞는 이름으로 정리했습니다.
* dev 환경에서 Bastion Host 리소스를 제거하였습니다.
  * Private Subnet에 위치한 RDS 및 ElastiCache 인바운드 규칙에 이미 API 서버 보안 그룹이 명시되어 있어, Bastion Host는 불필요한 리소스로 판단하여 삭제했습니다.